### PR TITLE
Food: 'use_by_date' Error

### DIFF
--- a/src/Food/food.py
+++ b/src/Food/food.py
@@ -12,7 +12,7 @@ class Food(object):
             # a food's quality will deteriorate after it is opened.
             self.use_by_date = timedelta(days = use_by_date)
         else:
-            self.use_by_date = use_by_date
+            self.use_by_date = timedelta(days = 14)
         self.isOpen = False
 
     ''' Following methods are comparators that will sort food items by expiration_date and name. 

--- a/tests/Food/test_food.py
+++ b/tests/Food/test_food.py
@@ -17,7 +17,7 @@ class Test_Food(unittest.TestCase):
         self.assertFalse(self.food.isOpen)  
         self.assertEqual("cheese", self.food2.name)
         self.assertEqual(date(2024, 6, 1), self.food2.expiration_date)
-        self.assertEqual(None, self.food2.use_by_date)
+        self.assertEqual(timedelta(days = 14), self.food2.use_by_date)
         self.assertFalse(self.food2.isOpen)  
     
     def testCompareFoods(self):


### PR DESCRIPTION
# Issue/Task:

https://fridgeventory.atlassian.net/browse/FRID-62
This is fixing a bug associated with Food object. 

A bug was discovered when user would try to save a profile after adding a food item that did not have a `use_by_date` (user skipped adding one). The following error would present itself:

`AttributeError: 'NoneType' object has no attribute 'days'`

Setting a default use by date of 14 days helped eliminate the error. 

# Checklist
- [X] Fixed Issue/Accomplished Task
- [X] Wrote tests
- [X] All test cases passing